### PR TITLE
add bg image and color options to sections

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -54,6 +54,22 @@
             "value": "highlight"
           }
         ]
+      },
+      {
+        "component": "text",
+        "name": "background-color",
+        "label": "Background Color",
+        "value": "",
+        "valueType": "string",
+        "description": "use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) html color names or css tokens"
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "background-image",
+        "label": "Background Image",
+        "description": "Background image of the section, displayed on top of the background color if specified",
+        "multi": false
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -64,7 +64,7 @@
         "description": "use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) html color names or css tokens"
       },
       {
-        "component": "reference",
+        "component": "text",
         "valueType": "string",
         "name": "background-image",
         "label": "Background Image",

--- a/models/_section.json
+++ b/models/_section.json
@@ -35,6 +35,22 @@
               "value": "highlight"
             }
           ]
+        },
+        {
+          "component": "text",
+          "name": "background-color",
+          "label": "Background Color",
+          "value": "",
+          "valueType": "string",
+          "description": "use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) html color names or css tokens"
+        },
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "background-image",
+          "label": "Background Image",
+          "description": "Background image of the section, displayed on top of the background color if specified",
+          "multi": false
         }
       ]
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -219,6 +219,77 @@ export function decorateButtons(main) {
   });
 }
 
+/* === SECTIONS === */
+
+/** Metadata keys consumed by {@link applySectionBackgroundDecorations} (not mirrored as data-*). */
+const SECTION_BACKGROUND_META_KEYS = new Set(['background-color', 'background-image']);
+
+/**
+ * Rejects values that could break out of a single CSS declaration when set via inline style.
+ * @param {string} value Trimmed color value
+ * @returns {boolean}
+ */
+function isSafeBackgroundColorValue(value) {
+  if (!value || value.length > 2000) return false;
+  if (/[;{}<>\n\r]/.test(value)) return false;
+  return true;
+}
+
+/**
+ * Allows only http(s) URLs for background images (same-origin relative paths resolve safely).
+ * Works with a dynamic media URL too.
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isAllowedBackgroundImageUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+  try {
+    const u = new URL(url.trim(), window.location.href);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * First string from metadata (handles single link vs array from readBlockConfig).
+ * @param {unknown} value
+ * @returns {string}
+ */
+function metaStringValue(value) {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') return value[0];
+  return '';
+}
+
+/**
+ * Sets inline background-color and optionally prepends a decorative .bg-image layer.
+ * Keys match section model fields and {@link readBlockConfig}: `background-color`, `background-image`.
+ * @param {HTMLElement} section
+ * @param {Record<string, unknown>} meta
+ */
+function applySectionBackgroundDecorations(section, meta) {
+  const color = metaStringValue(meta['background-color']).trim();
+  if (color && isSafeBackgroundColorValue(color)) {
+    section.style.setProperty('background-color', color);
+  }
+
+  const imageUrl = metaStringValue(meta['background-image']).trim();
+  if (!imageUrl || !isAllowedBackgroundImageUrl(imageUrl)) return;
+
+  const bg = document.createElement('div');
+  bg.className = 'bg-image';
+  const picture = document.createElement('picture');
+  const img = document.createElement('img');
+  img.src = imageUrl;
+  img.alt = 'decorative background';
+  img.loading = 'lazy';
+  img.decoding = 'async'; // prevent blocking the main thread
+  picture.append(img);
+  bg.append(picture);
+  section.prepend(bg);
+}
+
 /**
  * Decorates all sections in a container element.
  * @param {Element} main The container element
@@ -270,14 +341,17 @@ export function decorateSections(main) {
             .filter((style) => style)
             .map((style) => toClassName(style.trim()));
           styles.forEach((style) => section.classList.add(style));
-        } else if (isSafeObjectKey(key)) {
+        } else if (isSafeObjectKey(key) && !SECTION_BACKGROUND_META_KEYS.has(key)) {
           section.setAttribute(`data-${key}`, String(value ?? ''));
         }
       });
+      applySectionBackgroundDecorations(section, meta);
       sectionMeta.parentNode.remove();
     }
   }
 }
+
+/* === END SECTIONS === */
 
 /**
  * Decorates the main element.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -230,7 +230,7 @@ const SECTION_BACKGROUND_META_KEYS = new Set(['background-color', 'background-im
  * @returns {boolean}
  */
 function isSafeBackgroundColorValue(value) {
-  if (!value || value.length > 2000) return false;
+  if (!value || value.length > 500) return false; // CWE-770
   if (/[;{}<>\n\r]/.test(value)) return false;
   return true;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -245,13 +245,43 @@ main img {
 
 /* sections */
 main > .section {
-  margin: 40px 0;
+  padding: 40px 0;
+  margin: 0;
 }
 
-main > .section > div {
+main > .section > div:not(.bg-image) {
   max-width: var(--max-width-site);
   margin: auto;
   padding: 0 24px;
+}
+
+/* Section metadata: background image sits behind content */
+main > .section:has(> .bg-image) {
+  position: relative;
+  overflow: hidden;
+}
+
+main > .section:has(> .bg-image) > div:not(.bg-image) {
+  position: relative;
+  z-index: 1;
+}
+
+main > .section > .bg-image {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+main > .section > .bg-image picture,
+main > .section > .bg-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+main > .section > .bg-image img {
+  object-fit: cover;
 }
 
 main > .section:first-of-type {
@@ -259,7 +289,7 @@ main > .section:first-of-type {
 }
 
 @media (width >= 900px) {
-  main > .section > div {
+  main > .section > div:not(.bg-image) {
     padding: 0 32px;
   }
 }

--- a/ue/models/section.json
+++ b/ue/models/section.json
@@ -26,6 +26,22 @@
               "value": "highlight"
             }
           ]
+        },
+        {
+          "component": "text",
+          "name": "background-color",
+          "label": "Background Color",
+          "value": "",
+          "valueType": "string",
+          "description": "use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) html color names or css tokens"
+        },
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "background-image",
+          "label": "Background Image",
+          "description": "Background image of the section, displayed on top of the background color if specified",
+          "multi": false
         }
       ]
     }

--- a/ue/models/section.json
+++ b/ue/models/section.json
@@ -36,7 +36,7 @@
           "description": "use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) html color names or css tokens"
         },
         {
-          "component": "reference",
+          "component": "text",
           "valueType": "string",
           "name": "background-image",
           "label": "Background Image",


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #29 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- added background-image and background-color section metadata to the UE files
- added related helper functions in scripts.js
- bg image can be a dynamic media URL too
- did not do anything special for mobile only image or to handle gradients for the boilerplate because I didn't want to overcomplicate the boilerplate
- assumed that this won't be used as the first hero area, and set image loading as lazy and async.

**Changed**

- updated decorateSections to invoke the new helper functions

**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

<img width="1170" height="1311" alt="image" src="https://github.com/user-attachments/assets/8cadf34b-f535-46a6-9697-f8ddc5f79f02" />

<img width="896" height="1125" alt="image" src="https://github.com/user-attachments/assets/3670c0eb-a1ed-428e-8dbc-a5c96e3d8449" />


> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--ise-boilerplate--aemdemos.aem.page/
- After: https://29-sectionbg--ise-boilerplate--aemdemos.aem.page/

