### PR TITLE
feat: add automated a11y testing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
+playwright.config.js
+tests/a11y/
 helix-importer-ui
 tools/**/*
 *.min.js

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,36 @@
+name: A11y
+
+on:
+  pull_request:
+
+jobs:
+  a11y:
+    name: a11y
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install chromium
+
+      - name: Extract After URL from PR description
+        id: extract-url
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          AFTER_URL=$(echo "$PR_BODY" | grep -i '^\s*-\s*After:' | head -1 | sed 's/.*After:[[:space:]]*//' | tr -d '[:space:]')
+          if [ -z "$AFTER_URL" ]; then
+            echo "❌ No After URL found in PR description. Please add a Test URLs section with an After URL."
+            exit 1
+          fi
+          echo "url=$AFTER_URL" >> $GITHUB_OUTPUT
+
+      - name: Run a11y tests
+        run: npm run test:a11y ${{ steps.extract-url.outputs.url }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ localhost-key.pem
 .cursor
 Trace*.json
 .migration/*
+
+# Playwright / a11y test artifacts
+playwright-report/
+test-results/

--- a/.hlxignore
+++ b/.hlxignore
@@ -7,3 +7,4 @@ package-lock.json
 test/
 workers/
 _*
+tests/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.1",
       "license": "Apache License 2.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.9.0",
         "@babel/core": "^7.29.0",
         "@babel/eslint-parser": "7.28.0",
+        "@playwright/test": "^1.44.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/git": "^10.0.1",
@@ -35,6 +37,19 @@
         "stylelint": "17.4.0",
         "stylelint-config-standard": "40.0.0",
         "ts-api-utils": "^2.4.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -993,6 +1008,22 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -2190,6 +2221,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -4183,6 +4224,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -9306,6 +9362,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@adobe/aem-block-collection",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "Apache License 2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:json:definitions": "merge-json-cli -i \"ue/models/component-definition.json\" -o \"component-definition.json\"",
     "build:json:filters": "merge-json-cli -i \"ue/models/component-filters.json\" -o \"component-filters.json\"",
     "prepare": "husky",
+    "postinstall": "playwright install chromium",
     "release": "semantic-release"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "fix-css": " stylelint --fix **/**/*.css",
     "fix-js": "eslint --fix **/**/*.js",
     "lint": "npm run lint:js && npm run lint:css",
+    "test:a11y": "node tests/a11y/run.js",
     "build:json": "npm-run-all -p build:json:models build:json:definitions build:json:filters",
     "build:json:models": "merge-json-cli -i \"ue/models/component-models.json\" -o \"component-models.json\"",
     "build:json:definitions": "merge-json-cli -i \"ue/models/component-definition.json\" -o \"component-definition.json\"",
@@ -55,6 +56,8 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^12.0.0",
-    "semantic-release": "^23.0.0"
+    "semantic-release": "^23.0.0",
+    "@playwright/test": "^1.44.0",
+    "@axe-core/playwright": "^4.9.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/a11y',
+  testMatch: '**/*.test.js',
+  timeout: 30000,
+  reporter: './tests/a11y/a11y.reporter.js',
+  use: {
+    browserName: 'chromium',
+    headless: true,
+    ignoreHTTPSErrors: true,
+  },
+  workers: 1, // Run sequentially — avoids race conditions on localhost
+});

--- a/tests/a11y/a11y.config.js
+++ b/tests/a11y/a11y.config.js
@@ -1,0 +1,38 @@
+/**
+ * A11y test configuration.
+ *
+ * wcagTags — axe-core rule tags to test against.
+ *   Supported values: wcag2a, wcag2aa, wcag21a, wcag21aa, wcag22aa
+ *   Current set covers all Level A and AA criteria from WCAG 2.0 through 2.2.
+ *   Level AAA is intentionally excluded — not legally required and not satisfiable
+ *   for all content types. If axe-core adds wcag23aa in future, add it here.
+ *
+ * failOnImpact — violation impact levels that cause a non-zero exit code.
+ *   Supported values: critical, serious, moderate, minor
+ *   moderate and minor are logged as warnings but never fail the run.
+ *
+ * urls — relative paths tested in Mode 1 (npm run test:a11y).
+ *   Combined with A11Y_BASE_URL env variable (default: http://localhost:3000).
+ *   Guidelines:
+ *   - Add one entry per unique block type (via its demo page)
+ *   - Add one entry per unique page template
+ *   - Paths must start with /
+ *   - When adding a new block to the project, add its demo page path here in the same PR
+ */
+export default {
+  wcagTags: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'],
+  failOnImpact: ['critical', 'serious'],
+  urls: [
+    '/',
+    '/docs/library/blocks/carousel',
+    '/docs/library/blocks/card-carousel',
+    '/docs/library/blocks/cards',
+    '/docs/library/blocks/columns',
+    '/docs/library/blocks/embed',
+    '/docs/library/blocks/form',
+    '/docs/library/blocks/fragment',
+    '/docs/library/blocks/hero',
+    '/docs/library/blocks/modal',
+    '/docs/library/blocks/accordion',
+  ],
+};

--- a/tests/a11y/a11y.reporter.js
+++ b/tests/a11y/a11y.reporter.js
@@ -1,0 +1,41 @@
+class A11yReporter {
+  constructor() {
+    this.passed = 0;
+    this.failed = 0;
+  }
+
+  onTestEnd(test, result) {
+    if (result.status === 'passed') {
+      this.passed += 1;
+      console.log(`  ✓  ${test.title}`);
+    } else {
+      this.failed += 1;
+      console.log(`  ✘  ${test.title}`);
+
+      // Replay captured console output from the test (console.warn/error → stderr, console.log → stdout)
+      const stderr = result.stderr.map((c) => (typeof c === 'string' ? c : c.toString())).join('');
+      if (stderr) process.stderr.write(stderr);
+      const stdout = result.stdout.map((c) => (typeof c === 'string' ? c : c.toString())).join('');
+      if (stdout) process.stdout.write(stdout);
+
+      // Print error message only — error.message never contains the snippet or file path
+      for (const error of result.errors) {
+        const message = (error.message || '').split('\n')[0].trim();
+        if (message) console.log(`     ${message}`);
+      }
+    }
+  }
+
+  onEnd() {
+    console.log('');
+    if (this.failed === 0) {
+      console.log(`${this.passed} passed`);
+    } else {
+      const parts = [`${this.failed} failed`];
+      if (this.passed > 0) parts.push(`${this.passed} passed`);
+      console.log(parts.join(', '));
+    }
+  }
+}
+
+export default A11yReporter;

--- a/tests/a11y/a11y.test.js
+++ b/tests/a11y/a11y.test.js
@@ -1,0 +1,53 @@
+import { test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import config from './a11y.config.js';
+
+const { wcagTags, failOnImpact, urls } = config;
+
+// Mode 2: URL passed as argument to run.js, forwarded via A11Y_URL env var
+const singleUrl = process.env.A11Y_URL || null;
+
+// Mode 1: build URL list from config + base URL
+const BASE_URL = process.env.A11Y_BASE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+const testUrls = singleUrl
+  ? [singleUrl]
+  : urls.map((path) => `${BASE_URL}${path}`);
+
+function runA11yTest(url) {
+  test(`a11y: ${url}`, async ({ page }) => {
+    await page.goto(url, { waitUntil: 'networkidle' });
+
+    const results = await new AxeBuilder({ page })
+      .withTags(wcagTags)
+      .analyze();
+
+    // Log warnings for impacts not in failOnImpact — never fail on these
+    const warnings = results.violations.filter((v) => !failOnImpact.includes(v.impact));
+    if (warnings.length > 0) {
+      console.warn(`\n⚠ Warnings on ${url} (not failing):`);
+      warnings.forEach((v) => {
+        console.warn(`  [${v.impact}] ${v.id}: ${v.description}`);
+        v.nodes.forEach((n) => console.warn(`    → ${n.html}`));
+      });
+    }
+
+    // Fail on impacts listed in failOnImpact
+    const violations = results.violations.filter((v) => failOnImpact.includes(v.impact));
+    if (violations.length > 0) {
+      console.error(`\n✖ Violations on ${url}:`);
+      violations.forEach((v) => {
+        console.error(`  [${v.impact}] ${v.id}: ${v.description}`);
+        console.error(`  Help: ${v.helpUrl}`);
+        v.nodes.forEach((n) => console.error(`    → ${n.html}`));
+      });
+    }
+
+    if (violations.length > 0) {
+      throw new Error(`Found ${violations.length} a11y violation(s) with impact [${failOnImpact.join(', ')}] on ${url}`);
+    }
+  });
+}
+
+for (const url of testUrls) {
+  runA11yTest(url);
+}

--- a/tests/a11y/run.js
+++ b/tests/a11y/run.js
@@ -1,0 +1,11 @@
+const { spawn } = require('child_process');
+const { resolve } = require('path');
+
+const url = process.argv[2];
+const env = { ...process.env };
+if (url) env.A11Y_URL = url;
+
+// Resolve the local playwright binary directly — avoids shell:true and its deprecation warning
+const pw = resolve('node_modules', '.bin', 'playwright');
+const child = spawn(pw, ['test'], { env, stdio: 'inherit' });
+child.on('exit', (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Issue

Fixes #60

## Summary

Implements automated accessibility testing aligned with Adobe's Basic Web Testing guidelines using Playwright and axe-core against WCAG 2.2 AA.

- **Phase 1 ✅** — local CLI execution
- **Phase 2 ✅** — PR GitHub Action

## Changes

- `tests/a11y/a11y.config.js` — configurable WCAG tags, failure impact threshold, and URL list
- `tests/a11y/a11y.test.js` — test runner supporting two execution modes
- `tests/a11y/a11y.reporter.js` — custom reporter for clean terminal output
- `tests/a11y/run.js` — wrapper script for URL argument handling
- `playwright.config.js` — minimal Playwright configuration (Chromium headless only)
- `.github/workflows/a11y.yml` — PR GitHub Action, reads After URL from PR description
- `package.json` — added `test:a11y` script and `@playwright/test`, `@axe-core/playwright` devDependencies
- `.gitignore` — excluded Playwright artifacts (`playwright-report/`, `test-results/`)
- `.hlxignore` — excluded `tests/` from AEM Code Sync
- `.eslintignore` — excluded `playwright.config.js` from import linting

## Usage

```bash
# Mode 1 — run against all URLs in a11y.config.js (default: localhost:3000)
npm run test:a11y

# Mode 1 — run against all URLs on a specific host
A11Y_BASE_URL=https://main--ise-boilerplate--aemdemos.aem.page npm run test:a11y

# Mode 2 — run against a single specific URL
npm run test:a11y https://main--ise-boilerplate--aemdemos.aem.page/blocks/accordion
```

## Notes

- WCAG scope and failure threshold are configurable in `tests/a11y/a11y.config.js` — no code changes needed to adjust
- Tests use `waitUntil: networkidle` to ensure EDS JavaScript block decoration is complete before scanning — required for accurate results on EDS pages
- The PR GitHub Action reads the After URL from the Test URLs section below — no additional input required from the developer
- To re-run the a11y check: click `...` next to `A11y / a11y` in the PR checks → **View details** → **Re-run jobs**

## Test URLs and instructions -- There can be more than 1 set

- Before: https://main--ise-boilerplate--aemdemos.aem.page/
- After: https://a11y--ise-boilerplate--aemdemos.aem.page/