### PR TITLE
fix: read live PR description via GitHub API and validate After URL branch

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -23,14 +23,25 @@ jobs:
       - name: Extract After URL from PR description
         id: extract-url
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          AFTER_URL=$(echo "$PR_BODY" | grep -i '^\s*-\s*After:' | head -1 | sed 's/.*After:[[:space:]]*//' | tr -d '[:space:]')
+          AFTER_URL=$(gh pr view ${{ github.event.pull_request.number }} --json body --jq '.body' | grep -i '^\s*-\s*After:' | head -1 | sed 's/.*After:[[:space:]]*//' | tr -d '[:space:]')
           if [ -z "$AFTER_URL" ]; then
             echo "❌ No After URL found in PR description. Please add a Test URLs section with an After URL."
             exit 1
           fi
           echo "url=$AFTER_URL" >> $GITHUB_OUTPUT
+
+      - name: Validate After URL branch
+        env:
+          AFTER_URL: ${{ steps.extract-url.outputs.url }}
+          PR_BRANCH: ${{ github.head_ref }}
+        run: |
+          URL_BRANCH=$(echo "$AFTER_URL" | sed 's|https://||' | cut -d'.' -f1 | sed 's/--.*//')
+          if [ "$URL_BRANCH" != "$PR_BRANCH" ]; then
+            echo "❌ After URL branch does not match PR branch. Please update the After URL in the PR description to point to the correct branch preview."
+            exit 1
+          fi
 
       - name: Run a11y tests
         run: npm run test:a11y ${{ steps.extract-url.outputs.url }}


### PR DESCRIPTION
## Issue

Fixes #73

## Description of what the PR is changing
1. Read the live PR description via the GitHub API
2. Validate the After URL branch matches the PR branch


## Test URLs and instructions

- Before: https://main--ise-boilerplate--aemdemos.aem.page/
- After: https://a11y--ise-boilerplate--aemdemos.aem.page/