### PR TITLE
85 fixcenter

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -5,10 +5,6 @@
   flex-direction: column; /* @boilerplate */
 }
 
-.columns img { /* @boilerplate */
-  width: 100%; /* @boilerplate */
-}
-
 .columns > div > div { /* @boilerplate */
   order: 1; /* @boilerplate */
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -539,8 +539,51 @@ function cleanAttributes(element) {
   });
 }
 
+function hoistAlignmentAcrossInlines(el) {
+  // Handles [[alignment-class]content] where content spans inline elements,
+  // causing the opening [[class] and closing ] to land in different text nodes.
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const textNodes = [];
+  let n = walker.nextNode();
+  while (n) { textNodes.push(n); n = walker.nextNode(); }
+
+  for (let i = 0; i < textNodes.length - 1; i += 1) {
+    const node = textNodes[i];
+    const text = node.nodeValue;
+    const openIdx = text.lastIndexOf('[[');
+    if (openIdx === -1) continue; // eslint-disable-line no-continue
+
+    const tail = text.slice(openIdx);
+    // If the bracket expression is fully contained in this node, replaceTextNode handles it
+    if (/^\[\[[^\]]+\][^\]]*\]/.test(tail)) continue; // eslint-disable-line no-continue
+
+    // eslint-disable-next-line sonarjs/slow-regex
+    const classMatch = tail.match(/^\[\[([a-zA-Z0-9_,-]+)\]/);
+    if (!classMatch) continue; // eslint-disable-line no-continue
+
+    const classes = parseClasses(classMatch[1]);
+    const alignClasses = classes.filter((c) => ALIGNMENT_CLASSES.has(c));
+    // Only handle pure-alignment spanning patterns; mixed (alignment + span classes) needs Range API
+    if (!alignClasses.length || classes.length !== alignClasses.length) continue; // eslint-disable-line no-continue
+
+    for (let j = i + 1; j < textNodes.length; j += 1) {
+      const closeNode = textNodes[j];
+      const closeText = closeNode.nodeValue;
+      const closeIdx = closeText.indexOf(']');
+      if (closeIdx === -1) continue; // eslint-disable-line no-continue
+
+      el.classList.add(...alignClasses);
+      node.nodeValue = text.slice(0, openIdx) + tail.slice(classMatch[0].length);
+      closeNode.nodeValue = closeText.slice(0, closeIdx) + closeText.slice(closeIdx + 1);
+      break;
+    }
+  }
+}
+
 export function decorateSpanTags(element) {
   element.querySelectorAll('h1, h2, h3, h4, h5, h6, p, li').forEach((el) => {
+    if (el.textContent.includes('[[')) hoistAlignmentAcrossInlines(el);
+
     const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
     const nodes = [];
     let node = walker.nextNode();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -365,6 +365,8 @@ export function decorateSections(main) {
  * Bracket syntax: [[class1,class2]text] → <span class="class1 class2">text</span>
  * Only alphanumeric, hyphen, and underscore are allowed in class names.
  * Malformed patterns (empty class list, invalid chars) are left unchanged.
+ * Alignment classes (center, left, right) are hoisted to the containing element
+ * instead of applied to a span.
  */
 
 function parseClasses(raw) {
@@ -380,6 +382,8 @@ function parseSplitClasses(raw) {
 }
 
 const SPLIT_INLINE_TAGS = new Set(['STRONG', 'EM', 'A', 'BR']);
+
+const ALIGNMENT_CLASSES = new Set(['center', 'left', 'right']);
 
 // eslint-disable-next-line sonarjs/slow-regex
 const SPLIT_OPEN_RE = /\[\[([a-z0-9,-]+)\]\s*$/;
@@ -406,12 +410,17 @@ function applySplitBoundaryPass(el) {
       const classes = openMatch ? parseSplitClasses(openMatch[1]) : [];
       const closeMatch = openMatch && classes.length ? next.nodeValue.match(/^\s*\]/) : null;
       if (closeMatch) {
-        const span = document.createElement('span');
-        span.className = classes.join(' ');
-        span.appendChild(mid);
-        el.insertBefore(span, next);
+        const alignClasses = classes.filter((c) => ALIGNMENT_CLASSES.has(c));
+        const regularClasses = classes.filter((c) => !ALIGNMENT_CLASSES.has(c));
+        if (alignClasses.length) el.classList.add(...alignClasses);
         prev.nodeValue = prev.nodeValue.slice(0, -openMatch[0].length);
         next.nodeValue = next.nodeValue.slice(closeMatch[0].length);
+        if (regularClasses.length) {
+          const span = document.createElement('span');
+          span.className = regularClasses.join(' ');
+          span.appendChild(mid);
+          el.insertBefore(span, next);
+        }
       }
     } else if (!isPrevText && mid.nodeType === Node.TEXT_NODE && !isNextText && next.children.length === 0) {
       // Pattern B: <inline>prefix[[</inline> "classes" <inline>]content]</inline>
@@ -424,12 +433,17 @@ function applySplitBoundaryPass(el) {
       const classes = parseSplitClasses(mid.nodeValue);
       if (isPrevInline && isNextInline && openerText.endsWith('[[') && classes.length
         && closerText.startsWith(']') && closerText.endsWith(']')) {
-        const insertRef = next.nextSibling;
-        const span = document.createElement('span');
-        span.className = classes.join(' ');
+        const alignClasses = classes.filter((c) => ALIGNMENT_CLASSES.has(c));
+        const regularClasses = classes.filter((c) => !ALIGNMENT_CLASSES.has(c));
+        if (alignClasses.length) el.classList.add(...alignClasses);
         next.textContent = closerText.slice(1, -1);
-        span.appendChild(next);
-        el.insertBefore(span, insertRef);
+        if (regularClasses.length) {
+          const insertRef = next.nextSibling;
+          const span = document.createElement('span');
+          span.className = regularClasses.join(' ');
+          span.appendChild(next);
+          el.insertBefore(span, insertRef);
+        }
         if (openerText === '[[') el.removeChild(prev);
         else prev.textContent = openerText.slice(0, -2);
         el.removeChild(mid);
@@ -454,7 +468,7 @@ export function applySpanTags(text) {
   });
 }
 
-function replaceTextNode(textNode) {
+function replaceTextNode(textNode, containingEl) {
   const text = textNode.nodeValue;
   const frag = document.createDocumentFragment();
   let lastIndex = 0;
@@ -475,10 +489,17 @@ function replaceTextNode(textNode) {
     if (!classes.length) {
       frag.appendChild(document.createTextNode(full));
     } else {
-      const span = document.createElement('span');
-      span.className = classes.join(' ');
-      span.textContent = content;
-      frag.appendChild(span);
+      const alignClasses = classes.filter((c) => ALIGNMENT_CLASSES.has(c));
+      const regularClasses = classes.filter((c) => !ALIGNMENT_CLASSES.has(c));
+      if (alignClasses.length && containingEl) containingEl.classList.add(...alignClasses);
+      if (regularClasses.length) {
+        const span = document.createElement('span');
+        span.className = regularClasses.join(' ');
+        span.textContent = content;
+        frag.appendChild(span);
+      } else {
+        frag.appendChild(document.createTextNode(content));
+      }
     }
 
     lastIndex = match.index + full.length;
@@ -527,7 +548,7 @@ export function decorateSpanTags(element) {
       if (node.nodeValue.includes('[[')) nodes.push(node);
       node = walker.nextNode();
     }
-    nodes.forEach(replaceTextNode);
+    nodes.forEach((n) => replaceTextNode(n, el));
     applySplitBoundaryPass(el);
   });
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -260,6 +260,22 @@ a:hover { /* @boilerplate */
   }
 }
 
+.left {
+  text-align: left;
+
+  &.columns > div > div {
+    justify-content: left;
+  }
+}
+
+.right {
+  text-align: right;
+
+  &.columns > div > div {
+    justify-content: right;
+  }
+}
+
 /* buttons */
 a.button,
 button { /* @boilerplate */


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #85 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**
Center, Left and Right are deemed "alignment" classes. Those are added to the parent element now instead of a Span.
This helps allow italic, bold, superscript text to be included in the alignment.

Elements without any [[ in their text content skip the pre-pass entirely at the cost of a single string scan. The hoistAlignmentAcrossInlines function only runs when there's something to process, and within it, each text node short-circuits on lastIndexOf('[[') === -1 before doing any heavier work.

**Changed**

- 

**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--ise-boilerplate--aemdemos.aem.page/drafts/sections
- After: https://85-fixcenter--ise-boilerplate--aemdemos.aem.page/drafts/sections