### PR TITLE
Add unique block IDs to accordion items for improved accessibility

### DIFF
--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,19 +1,37 @@
-import { moveInstrumentation } from '../../scripts/scripts.js';
+import { moveInstrumentation, getBlockId } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
+  // Unique id per block instance (e.g. accordion_0, accordion_1, ...) so multiple
+  // accordions on the same page, and their items, can be targeted individually by
+  // analytics/Target requests.
+  const blockId = getBlockId('accordion');
+  block.setAttribute('id', blockId);
+  block.setAttribute('role', 'region');
+  block.setAttribute('aria-label', `Accordion ${blockId}`);
+
   const ul = document.createElement('ul');
-  [...block.children].forEach((row) => {
+  [...block.children].forEach((row, i) => {
     const li = document.createElement('li');
     li.className = 'accordion-item';
     moveInstrumentation(row, li);
     while (row.firstElementChild) li.append(row.firstElementChild);
 
     const [label, body] = [...li.children];
+    const labelId = `${blockId}-label-${i}`;
+    const bodyId = `${blockId}-body-${i}`;
     if (label !== null && label !== undefined) {
       label.className = 'accordion-item-label';
+      label.id = labelId;
+      // aria-controls/aria-labelledby link label <-> body for screen readers,
+      // since toggling only relies on a CSS class today.
+      label.setAttribute('aria-controls', bodyId);
       label.addEventListener('click', () => li.classList.toggle('active'));
     }
-    if (body !== null && body !== undefined) body.className = 'accordion-item-body';
+    if (body !== null && body !== undefined) {
+      body.className = 'accordion-item-body';
+      body.id = bodyId;
+      body.setAttribute('aria-labelledby', labelId);
+    }
 
     ul.append(li);
   });


### PR DESCRIPTION

## Issue
See the tabs.js for context; https://github.com/aemdemos/lundbeck-xenazineusa/blob/main/blocks/tabs/tabs.js
Import and apply blockId to https://github.com/aemdemos/ise-boilerplate/blob/main/blocks/accordion/accordion.js.

we want to apply an id to each .accordion-item-label and .accordion-item-body. This helps with analytics and Target requests from customers, as well as potentially allowing for deep-linking to open a specific accordion item.


Fixes #98 

## Description of what the PR is changing
Applied an id to each .accordion-item-label and .accordion-item-body.


This is code change.

TEST URL :

https://98-add-blockid-to-accordion--ise-boilerplate--aemdemos.aem.page/docs/library/blocks/accordion

How to validate the changes 
In DevTools (Elements panel or Console), check:

The .accordion block has id="accordion_0", role="region", aria-label="Accordion accordion_0".
Each .accordion-item-label has a unique id (accordion_0-label-0, -1, ...) and aria-controls pointing to its matching body id.
Each .accordion-item-body has a unique id (accordion_0-body-0, ...) and aria-labelledby pointing back to its label.
If there's more than one accordion block on the page, the second instance should be accordion_1, confirming the counter increments per block type, not per page.

For example : should see the below
<div class="accordion-item-label" id="accordion_0-label-0" aria-controls="accordion_0-body-0"><p>Why was the accordion.js changed from boilerplate?</p></div>


